### PR TITLE
Fix src subpath strings breaking eval-only commands on Lix

### DIFF
--- a/nix/bun2nix.nix
+++ b/nix/bun2nix.nix
@@ -25,7 +25,7 @@ in
             src = ../programs/bun2nix;
 
             cargoLock = {
-              lockFile = "${finalAttrs.src}/Cargo.lock";
+              lockFile = finalAttrs.src + "/Cargo.lock";
             };
 
             passthru = with config; {

--- a/nix/bun2nix/bun2nix-js.nix
+++ b/nix/bun2nix/bun2nix-js.nix
@@ -14,11 +14,11 @@
           src = ../../programs/bun2nix;
 
           cargoLock = {
-            lockFile = "${finalAttrs.src}/Cargo.lock";
+            lockFile = finalAttrs.src + "/Cargo.lock";
           };
 
           bunDeps = final.bun2nix.fetchBunDeps {
-            bunNix = "${finalAttrs.src}/bun.nix";
+            bunNix = finalAttrs.src + "/bun.nix";
           };
 
           nativeBuildInputs = with final; [

--- a/nix/fetch-bun-deps/cache-entry-creator.nix
+++ b/nix/fetch-bun-deps/cache-entry-creator.nix
@@ -6,7 +6,7 @@
       packages.cacheEntryCreator = pkgs.stdenvNoCC.mkDerivation (
         finalAttrs:
         let
-          depsNix = "${finalAttrs.src}/deps.nix";
+          depsNix = finalAttrs.src + "/deps.nix";
         in
         {
           pname = "bun2nix-cache-entry-creator";

--- a/nix/fetch-bun-deps/patched-dependencies-to-overrides.nix
+++ b/nix/fetch-bun-deps/patched-dependencies-to-overrides.nix
@@ -20,7 +20,7 @@ in
           src = ./.;
           packageJsonPath = ./package.json;
           packageJsonContents = lib.importJSON packageJsonPath;
-          patchedDependencies = lib.mapAttrs (_: path: "''${src}/''${path}") (
+          patchedDependencies = lib.mapAttrs (_: path: src + "/''${path}") (
             packageJsonContents.patchedDependencies or { }
           );
           patchOverrides = bun2nix.patchedDependenciesToOverrides {

--- a/templates/patched-deps-scoped/default.nix
+++ b/templates/patched-deps-scoped/default.nix
@@ -10,7 +10,7 @@
 let
   src = ./.;
   packageJsonContents = lib.importJSON ./package.json;
-  patchedDependencies = lib.mapAttrs (_: path: "${src}/${path}") (
+  patchedDependencies = lib.mapAttrs (_: path: src + "/${path}") (
     packageJsonContents.patchedDependencies or { }
   );
   patchOverrides = bun2nix.patchedDependenciesToOverrides {

--- a/templates/patched-deps/default.nix
+++ b/templates/patched-deps/default.nix
@@ -7,7 +7,7 @@ let
   src = ./.;
   packageJsonPath = ./package.json;
   packageJsonContents = lib.importJSON packageJsonPath;
-  patchedDependencies = lib.mapAttrs (_: path: "${src}/${path}") (
+  patchedDependencies = lib.mapAttrs (_: path: src + "/${path}") (
     packageJsonContents.patchedDependencies or { }
   );
   patchOverrides = bun2nix.patchedDependenciesToOverrides {


### PR DESCRIPTION
## Problem

Interpolating a source path into a string, such as
`"${finalAttrs.src}/deps.nix"`, copies the source directory to a separate
store path. Reading that string back during evaluation requires the copy to
already exist.

Lix 2.95.2 does not realize that copy during eval-only commands. On a cold
store, `nix flake check --no-build` therefore aborts with:

```text
error: path '/nix/store/...-cache-entry-creator' did not exist in the store during evaluation
```

The issue surfaces through `callPackage` in
`nix/fetch-bun-deps/cache-entry-creator.nix` and `importCargoLock` in the two
bun2nix package definitions. After fixing those paths, the patched dependency
templates expose the same issue when `builtins.path` reads an interpolated
patch path:

```text
error: path '/nix/store/...-patched-deps' did not exist in the store during evaluation
```

CppNix realizes these copies during evaluation, which masks the problem.

## Reproduction

On Lix 2.95.2, change a tracked file under
`programs/cache-entry-creator` on upstream `master` so its source store path is
not already populated, then run:

```console
$ nix flake check --no-build path:.
error: path '/nix/store/...-cache-entry-creator' did not exist in the store during evaluation
```

With the four internal path fixes applied, the command advances to the
equivalent `patched-deps` error. With all changes in this PR applied, the same
cold-store check exits successfully.

## Fix

Use path addition for all seven affected source subpaths:

- Four internal `finalAttrs.src` references used by `callPackage`,
  `importCargoLock`, and `fetchBunDeps`.
- Two patched dependency templates.
- The public `patchedDependenciesToOverrides` option example.

This keeps each value as a path, avoids an unnecessary source copy, and works
under both Lix and CppNix.

## Validation

- `nix fmt`
- `nix flake check --no-build`
- Cold-store regression probe on Lix 2.95.2: upstream `master` fails with the
  `cache-entry-creator` error, while this branch passes.
- `nix build --no-link .#packages.x86_64-linux.bun2nix .#packages.x86_64-linux.bun2nix-js .#packages.x86_64-linux.cacheEntryCreator .#checks.x86_64-linux.default .#checks.x86_64-linux.patched-deps .#checks.x86_64-linux.patched-deps-scoped .#checks.x86_64-linux.treefmt`

The full `nix flake check` reaches the build phase but is currently blocked by
the pre-existing `arbitraryInstallCompletes` fixed-output hash mismatch. The
same check fails on upstream `master`:

```text
specified: sha256-mYoND6xD+uEgKjq17hDWPe5pEEnwmSNfHPCqE4R+B5E=
got:       sha256-TF+PP7VIIRPSol33Usz4PiYlTzs7M0wRqnQMGojCygc=
```
