### PR TITLE
Fail fast on package.json/bun.lock drift and stop rewriting non-registry catalog refs

### DIFF
--- a/nix/checks/lockfile-drift-detection.nix
+++ b/nix/checks/lockfile-drift-detection.nix
@@ -1,0 +1,161 @@
+# Guards the hook's offline-install prep script (resolve-catalog.ts):
+#
+# 1. A bun.lock whose trustedDependencies / patchedDependencies drifted from
+#    package.json must fail fast with a diagnostic naming the drifted
+#    entries.  Without the check, bun silently re-resolves the affected
+#    dependencies at install time and the drift surfaces as a wall of
+#    ConnectionRefused errors in the sandbox with no hint of the cause.
+# 2. Sections that merely list the same entries in a different order must
+#    NOT trip the check.
+# 3. `catalog:` references resolving to registry versions are rewritten to
+#    the exact version, but references resolving to non-registry specs
+#    (github:, git+, tarball URLs, file:) must be left alone — rewriting
+#    them registers as a changed spec and forces the same re-resolve.
+#
+# The drifted fixture deliberately contains no `catalog:` refs, pinning that
+# the drift check runs for plain projects too, not only catalog users.
+_: {
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.lockfileDriftDetection = pkgs.stdenv.mkDerivation {
+        name = "lockfile-drift-detection";
+
+        dontUnpack = true;
+
+        nativeBuildInputs = [ pkgs.bun ];
+
+        buildPhase = ''
+          export HOME="$TMPDIR"
+          script=${../mk-derivation/resolve-catalog.ts}
+
+          run() {
+            rc=0
+            bun --config=/dev/null --no-install "$script" "$1" >log.txt 2>&1 || rc=$?
+          }
+
+          expect() {
+            if ! grep -qF "$1" log.txt; then
+              echo "expected output to contain: $1"
+              cat log.txt
+              exit 1
+            fi
+          }
+
+          # --- drifted: both sections disagree with package.json ---
+          mkdir drifted
+          cat > drifted/package.json <<'EOF'
+          {
+            "name": "fixture",
+            "version": "1.0.0",
+            "trustedDependencies": ["node-pty"],
+            "patchedDependencies": { "left-pad@1.3.0": "patches/left-pad.patch" }
+          }
+          EOF
+          cat > drifted/bun.lock <<'EOF'
+          {
+            "lockfileVersion": 1,
+            "workspaces": { "": { "name": "fixture" } },
+            "trustedDependencies": ["esbuild"],
+            "packages": {}
+          }
+          EOF
+
+          run drifted
+          if [ "$rc" -eq 0 ]; then
+            echo "drifted fixture: expected failure, got exit 0"
+            cat log.txt
+            exit 1
+          fi
+          expect "bun.lock is out of sync with package.json"
+          expect "missing from bun.lock: node-pty"
+          expect "only in bun.lock: esbuild"
+          expect "patchedDependencies differ for: left-pad@1.3.0"
+          echo "drifted fixture: failed with diagnostic, as intended"
+
+          # --- synced: same entries, different order ---
+          mkdir synced
+          cat > synced/package.json <<'EOF'
+          {
+            "name": "fixture",
+            "version": "1.0.0",
+            "trustedDependencies": ["b-pkg", "a-pkg"],
+            "patchedDependencies": { "x@1.0.0": "patches/x.patch" }
+          }
+          EOF
+          cat > synced/bun.lock <<'EOF'
+          {
+            "lockfileVersion": 1,
+            "workspaces": { "": { "name": "fixture" } },
+            "trustedDependencies": ["a-pkg", "b-pkg"],
+            "patchedDependencies": { "x@1.0.0": "patches/x.patch" },
+            "packages": {}
+          }
+          EOF
+
+          run synced
+          if [ "$rc" -ne 0 ]; then
+            echo "synced fixture: expected success, got exit $rc"
+            cat log.txt
+            exit 1
+          fi
+          echo "synced fixture: passed, ordering ignored"
+
+          # --- catalog: registry ref rewritten, non-registry ref preserved ---
+          mkdir catalog
+          cat > catalog/package.json <<'EOF'
+          {
+            "name": "fixture",
+            "version": "1.0.0",
+            "dependencies": {
+              "bar": "catalog:",
+              "foo": "catalog:"
+            }
+          }
+          EOF
+          cat > catalog/bun.lock <<'EOF'
+          {
+            "lockfileVersion": 1,
+            "workspaces": {
+              "": {
+                "name": "fixture",
+                "dependencies": { "bar": "catalog:", "foo": "catalog:" }
+              }
+            },
+            "catalog": {
+              "bar": "^1.0.0",
+              "foo": "github:user/repo#abcdef"
+            },
+            "packages": {
+              "bar": ["bar@1.2.3", "", {}, "sha512-aaa"],
+              "foo": ["foo@github:user/repo#abcdef", {}, "abcdef"]
+            }
+          }
+          EOF
+
+          run catalog
+          if [ "$rc" -ne 0 ]; then
+            echo "catalog fixture: expected success, got exit $rc"
+            cat log.txt
+            exit 1
+          fi
+          if ! grep -qF '"bar": "1.2.3"' catalog/package.json; then
+            echo "catalog fixture: registry ref not rewritten to exact version"
+            cat catalog/package.json
+            exit 1
+          fi
+          if ! grep -qF '"foo": "catalog:"' catalog/package.json; then
+            echo "catalog fixture: non-registry ref was rewritten; must stay catalog:"
+            cat catalog/package.json
+            exit 1
+          fi
+          echo "catalog fixture: rewrite behavior correct"
+        '';
+
+        installPhase = ''
+          mkdir -p "$out"
+          echo "lockfileDriftDetection: PASS" > "$out/result"
+        '';
+      };
+    };
+}

--- a/nix/mk-derivation/hook.sh
+++ b/nix/mk-derivation/hook.sh
@@ -83,14 +83,14 @@ function bunPatchPhase {
   runHook postBunPatchPhase
 }
 
-# bun re-resolves `catalog:` dependency specifiers against the npm registry on
-# every `bun install`, even with a fully populated cache. In the Nix sandbox
-# this fails. The lockfile already records the exact resolved version for
-# every package, so rewrite every `catalog:` reference (in bun.lock's
-# `workspaces` section and in every workspace package.json) to that exact
-# version (or `workspace:*` for workspace packages) before `bun install`.
-function bunResolveCatalogRefs {
-  if ! [ -f bun.lock ] || ! grep -q '"catalog:' bun.lock 2>/dev/null; then
+# Prepare the project for offline install: rewrite `catalog:` references to
+# the exact versions recorded in bun.lock (bun re-resolves them against the
+# registry otherwise, which fails in the sandbox), and fail fast if bun.lock
+# has drifted from package.json (drift makes bun re-resolve, with the same
+# result). Runs whenever a lockfile exists — the drift check applies to every
+# project, not just those using catalogs.
+function bunPrepareOfflineInstall {
+  if ! [ -f bun.lock ]; then
     return 0
   fi
   # --config=/dev/null: ignore the project's bunfig.toml, which may remap
@@ -103,7 +103,7 @@ function bunNodeModulesInstallPhase {
   pushd "$bunRoot" || exit 1
   runHook preBunNodeModulesInstallPhase
 
-  bunResolveCatalogRefs
+  bunPrepareOfflineInstall
 
   # Remove patchedDependencies from package.json and bun.lock since we
   # pre-patch packages during the Nix build. This ensures bun looks for

--- a/nix/mk-derivation/resolve-catalog.ts
+++ b/nix/mk-derivation/resolve-catalog.ts
@@ -1,12 +1,21 @@
-// bun2nix: resolve `catalog:` specifiers to exact versions for offline install.
+// bun2nix: prepare the project for offline install.
 //
-// bun re-resolves `catalog:` dependency specifiers against the npm registry on
-// every `bun install`, even with a fully populated cache and
-// `--frozen-lockfile` / `--offline`. In the Nix sandbox this fails. The
-// lockfile already records the exact resolved version for every package, so
-// rewrite every `catalog:` reference (in bun.lock's `workspaces` section and
-// in every workspace package.json) to that exact version (or `workspace:*`
-// for workspace packages) before `bun install` runs.
+// Both steps exist because bun re-resolves any dependency whose recorded
+// state drifted from package.json — and re-resolving git/github/
+// remote-tarball deps downloads them unconditionally, which fails in the Nix
+// sandbox no matter how complete the cache is:
+//
+// 1. Resolve `catalog:` specifiers to exact versions (older bun re-resolves
+//    them against the registry on every `bun install`). Non-registry catalog
+//    values (github:/git+/tarball URLs) are left as `catalog:` — bun resolves
+//    those natively from the lockfile's catalog section, and rewriting them
+//    would itself register as a changed spec and force a re-resolve.
+// 2. Detect `trustedDependencies` / `patchedDependencies` drift between the
+//    root package.json and bun.lock, and fail with an actionable message.
+//    Projects routinely commit a bun.lock whose copies of these sections lag
+//    package.json; any mismatch makes bun distrust the lockfile mapping
+//    wholesale, and the resulting re-resolution surfaces as a wall of
+//    ConnectionRefused errors long after the actual cause.
 //
 // Invoked as: bun resolve-catalog.ts <bunRoot>
 
@@ -29,6 +38,8 @@ interface BunLock {
   catalog?: Deps;
   catalogs?: Record<string, Deps>;
   packages?: Record<string, [string, ...unknown[]]>;
+  trustedDependencies?: string[];
+  patchedDependencies?: Deps;
 }
 
 const depSections = [
@@ -42,7 +53,7 @@ const root = process.argv[2] ?? ".";
 const lockPath = join(root, "bun.lock");
 
 if (!existsSync(lockPath)) process.exit(0);
-if (!readFileSync(lockPath, "utf8").includes('"catalog:')) process.exit(0);
+const hasCatalogRefs = readFileSync(lockPath, "utf8").includes('"catalog:');
 
 // bun.lock is JSON-with-trailing-commas. Bun's module loader has a built-in
 // JSONC parser (used for tsconfig.json / bun.lock) that we can reach via
@@ -71,6 +82,20 @@ for (const [name, entry] of Object.entries(packages)) {
   resolved[name] = spec.slice(prefix.length);
 }
 
+// A spec whose resolution is not a plain registry version. Rewriting a
+// `catalog:` reference to one of these would change the dependency's spec
+// string and force bun to re-resolve (= re-download) it; bun resolves these
+// natively from the lockfile's catalog section, so leave them alone.
+function isNonRegistrySpec(spec: string): boolean {
+  return (
+    spec.startsWith("github:") ||
+    spec.startsWith("git+") ||
+    spec.startsWith("http://") ||
+    spec.startsWith("https://") ||
+    spec.startsWith("file:")
+  );
+}
+
 function cresolve(name: string, spec: string): string {
   const cname = spec.slice("catalog:".length);
   const table = cname === "" ? catalog : (catalogs[cname] ?? {});
@@ -79,6 +104,8 @@ function cresolve(name: string, spec: string): string {
   if (typeof cv === "string" && cv.startsWith("workspace:")) return cv;
   if (typeof rv === "string" && rv.startsWith("workspace:"))
     return "workspace:*";
+  if (typeof cv === "string" && isNonRegistrySpec(cv)) return spec;
+  if (typeof rv === "string" && isNonRegistrySpec(rv)) return spec;
   if (typeof rv === "string") return rv;
   if (typeof cv === "string") return cv;
   return spec;
@@ -99,25 +126,79 @@ function rewriteDeps(holder: DepHolder): boolean {
   return changed;
 }
 
-console.log("bun2nix: resolving catalog: specifiers from bun.lock");
-
-// Rewrite the lockfile's workspaces section.
 let lockChanged = false;
-for (const ws of Object.values(workspaces)) {
-  if (rewriteDeps(ws)) lockChanged = true;
+
+if (hasCatalogRefs) {
+  console.log("bun2nix: resolving catalog: specifiers from bun.lock");
+
+  // Rewrite the lockfile's workspaces section.
+  for (const ws of Object.values(workspaces)) {
+    if (rewriteDeps(ws)) lockChanged = true;
+  }
+
+  // Rewrite every workspace package.json (root "" + each workspace dir).
+  for (const wsDir of Object.keys(workspaces)) {
+    const pkgJson = join(root, wsDir, "package.json");
+    if (!existsSync(pkgJson)) continue;
+    const text = readFileSync(pkgJson, "utf8");
+    if (!text.includes('"catalog:')) continue;
+    const pkg = JSON.parse(text) as DepHolder;
+    if (rewriteDeps(pkg)) {
+      writeFileSync(pkgJson, JSON.stringify(pkg, null, 2) + "\n");
+    }
+  }
 }
+
 if (lockChanged) {
   writeFileSync(lockPath, JSON.stringify(lock, null, 2) + "\n");
 }
 
-// Rewrite every workspace package.json (root "" + each workspace dir).
-for (const wsDir of Object.keys(workspaces)) {
-  const pkgJson = join(root, wsDir, "package.json");
-  if (!existsSync(pkgJson)) continue;
-  const text = readFileSync(pkgJson, "utf8");
-  if (!text.includes('"catalog:')) continue;
-  const pkg = JSON.parse(text) as DepHolder;
-  if (rewriteDeps(pkg)) {
-    writeFileSync(pkgJson, JSON.stringify(pkg, null, 2) + "\n");
+// Fail fast on trustedDependencies / patchedDependencies drift between the
+// root package.json and bun.lock. Compared as a set / as key-value pairs so
+// pure ordering differences don't trip the check.
+const rootPkgPath = join(root, "package.json");
+if (existsSync(rootPkgPath)) {
+  const rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf8")) as {
+    trustedDependencies?: string[];
+    patchedDependencies?: Deps;
+  };
+
+  const drift: string[] = [];
+
+  const pkgTrusted = [...(rootPkg.trustedDependencies ?? [])].sort();
+  const lockTrusted = [...(lock.trustedDependencies ?? [])].sort();
+  if (JSON.stringify(pkgTrusted) !== JSON.stringify(lockTrusted)) {
+    const missing = pkgTrusted.filter((n) => !lockTrusted.includes(n));
+    const extra = lockTrusted.filter((n) => !pkgTrusted.includes(n));
+    drift.push(
+      `trustedDependencies differ` +
+        (missing.length
+          ? `; missing from bun.lock: ${missing.join(", ")}`
+          : "") +
+        (extra.length ? `; only in bun.lock: ${extra.join(", ")}` : ""),
+    );
+  }
+
+  const pkgPatched = rootPkg.patchedDependencies ?? {};
+  const lockPatched = lock.patchedDependencies ?? {};
+  const patchKeys = [
+    ...new Set([...Object.keys(pkgPatched), ...Object.keys(lockPatched)]),
+  ].sort();
+  const patchDiffs = patchKeys.filter((k) => pkgPatched[k] !== lockPatched[k]);
+  if (patchDiffs.length) {
+    drift.push(`patchedDependencies differ for: ${patchDiffs.join(", ")}`);
+  }
+
+  if (drift.length) {
+    console.error(`
+bun2nix: error: bun.lock is out of sync with package.json:
+${drift.map((d) => `  - ${d}`).join("\n")}
+
+bun re-resolves dependencies when these sections drift, and re-resolving
+git/github/tarball dependencies requires network access, which is not
+available in the Nix sandbox. Run \`bun install\` to refresh bun.lock,
+commit the result, and regenerate bun.nix.
+`);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
Two fixes to the install hook's offline-prep step, both stemming from the same bun behavior: any drift between package.json and bun.lock makes bun re-resolve the affected dependencies, and re-resolving a git/github/remote-tarball dependency downloads it unconditionally — fatal in the Nix sandbox no matter how complete the cache is. Both were found getting the opencode workspace (~3,200 packages, the reproduction from #77) to install offline, but neither depends on the manifest-cache work in the follow-up PR: the hook doesn't pass `--frozen-lockfile`, so both failure modes are reachable on master today.

- **Drift detection.** Projects routinely commit a bun.lock whose `trustedDependencies` / `patchedDependencies` sections lag package.json (opencode's does). Any mismatch makes bun distrust the lockfile mapping wholesale, and the re-resolution surfaces as a wall of `ConnectionRefused` errors at resolve time with no hint of the cause. The hook's prep script now compares those sections (as a set / as key-value pairs, so pure ordering differences don't count) and fails up front with the actual diagnosis and the fix: refresh bun.lock, commit, regenerate bun.nix. This is deliberately a hard error rather than a silent sync — a lockfile that disagrees with package.json means the dependency cache was generated from something other than what the project declares.
- **Non-registry catalog refs.** The `catalog:` rewrite was converting refs to their resolution even when that resolution is a github/git/tarball/file spec. That substitution itself registers as a changed spec and forces the same network re-resolve. Those refs are now left as `catalog:` — bun resolves them natively from the lockfile's catalog section.

The prep script also runs whenever bun.lock exists now, not only when it contains `catalog:` refs, so the drift check covers every project.

Testing: a new flake check (`lockfileDriftDetection`) runs the prep script against three fixtures — drifted sections must fail naming the drifted entries, identical-but-reordered sections must pass, and a catalog with both a registry and a github ref must rewrite the former and preserve the latter. It's non-vacuous: against the current script it fails with "drifted fixture: expected failure, got exit 0". End-to-end, opencode-as-committed dies in seconds with the drift diagnostic instead of twenty minutes of `ConnectionRefused`; with its lockfile refreshed it proceeds normally.

Compatibility: builds of projects with a synced lockfile are unaffected. Projects with drifted lockfiles previously failed at resolve time with inscrutable network errors; they now fail earlier with an actionable message. A project whose bun.lock has a non-registry catalog entry was previously broken by the rewrite itself; it now builds.

This is the second of three PRs from getting the full opencode workspace building offline; it stands alone and doesn't depend on the others.
