### PR TITLE
fix(lockfile): parse git and github deps that carry an integrity hash

### DIFF
--- a/programs/bun2nix/src/lockfile.rs
+++ b/programs/bun2nix/src/lockfile.rs
@@ -15,7 +15,8 @@ use crate::{
 mod package_deserializer;
 mod package_visitor;
 pub use package_deserializer::{
-    PackageDeserializer, drain_package_specifier, drop_prefix, split_once_owned, swap_remove_value,
+    PackageDeserializer, drain_package_specifier, drop_prefix, is_git_or_github_identifier,
+    split_once_owned, swap_remove_value,
 };
 pub use package_visitor::PackageVisitor;
 

--- a/programs/bun2nix/src/lockfile/package_deserializer.rs
+++ b/programs/bun2nix/src/lockfile/package_deserializer.rs
@@ -34,9 +34,27 @@ impl PackageDeserializer {
             1 => deserializer.deserialize_workspace_package(),
             2 => deserializer.deserialize_tarball_or_file_package(),
             3 => deserializer.deserialize_tarball_git_or_github_package(),
+            // Newer versions of bun record an integrity hash for git and
+            // github dependencies, which gives their entries the same arity
+            // as an npm package. Dispatch on the specifier so they are not
+            // mistaken for one.
+            4 if deserializer.has_git_or_github_specifier() => {
+                deserializer.deserialize_tarball_git_or_github_package()
+            }
             4 => deserializer.deserialize_npm_package(),
             x => Err(Error::UnexpectedPackageEntryLength(x)),
         }
+    }
+
+    /// # Has a Git or Github Specifier
+    ///
+    /// Peek at the entry's identifier to decide whether it describes a git or
+    /// github dependency, without consuming the entry.
+    fn has_git_or_github_specifier(&self) -> bool {
+        self.values
+            .first()
+            .and_then(|value| value.as_str())
+            .is_some_and(is_git_or_github_identifier)
     }
 
     /// # Deserialize an NPM Package
@@ -90,6 +108,10 @@ impl PackageDeserializer {
     /// specifier prefix decides between them - `http` is a
     /// tarball (bun records an integrity hash for these), `github:`
     /// is a github package, and anything else is a git package
+    ///
+    /// Newer versions of bun append an integrity hash to git and github
+    /// entries, making them a tuple of arity 4; only the identifier is
+    /// needed here, so both shapes are handled by this method
     pub fn deserialize_tarball_git_or_github_package(mut self) -> Result<Package> {
         let id = swap_remove_value(&mut self.values, 0);
         let specifier = drain_package_specifier(id).ok_or(Error::NoAtInPackageIdentifier)?;
@@ -316,6 +338,43 @@ pub fn drain_package_specifier(mut id: String) -> Option<String> {
     let sep = id[search_start..].find('@')? + search_start;
 
     Some(id.drain(sep + 1..).collect())
+}
+
+/// # Is a Git or Github Package Identifier
+///
+/// Checks whether a bun package identifier of the form `<name>@<specifier>`
+/// resolves to a git or github dependency.
+///
+/// Bun writes these as `<name>@github:<owner>/<repo>#<rev>` or
+/// `<name>@git+<url>#<rev>`, which cannot be told apart from an npm identifier
+/// by the entry's arity alone once bun records an integrity hash for them.
+///
+///```rust
+/// use bun2nix::lockfile::is_git_or_github_identifier;
+///
+/// // Github dependencies, scoped and unscoped
+/// assert!(is_git_or_github_identifier("dayjs@github:iamkun/dayjs#45bf6a3"));
+/// assert!(is_git_or_github_identifier("@solidjs/start@github:solidjs/start#dfb2020"));
+///
+/// // Git dependencies
+/// assert!(is_git_or_github_identifier(
+///     "@my/pkg@git+ssh://git@github.com/my/pkg.git#abc123"
+/// ));
+///
+/// // Npm dependencies and malformed identifiers are not
+/// assert!(!is_git_or_github_identifier("@types/bun@1.2.4"));
+/// assert!(!is_git_or_github_identifier("zod@3.21.4"));
+/// assert!(!is_git_or_github_identifier(
+///     "zod@https://registry.npmjs.org/zod/-/zod-3.21.4.tgz"
+/// ));
+/// assert!(!is_git_or_github_identifier("no-at-here"));
+/// ```
+pub fn is_git_or_github_identifier(id: &str) -> bool {
+    let Some(specifier) = drain_package_specifier(id.to_owned()) else {
+        return false;
+    };
+
+    specifier.starts_with("github:") || specifier.starts_with("git+")
 }
 
 /// # Split Once (Owned)

--- a/programs/bun2nix/src/package/fetcher.rs
+++ b/programs/bun2nix/src/package/fetcher.rs
@@ -135,6 +135,12 @@ impl Fetcher {
     ///     Fetcher::to_npm_url(npm_identifier, Some("https://npm.pkg.github.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz")).unwrap(),
     ///     "https://npm.pkg.github.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz"
     /// );
+    ///
+    /// // Unscoped packages
+    /// assert_eq!(
+    ///     Fetcher::to_npm_url("zod@3.21.4", None).unwrap(),
+    ///     "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz"
+    /// );
     /// ```
     pub fn to_npm_url(ident: &str, tarball_url: Option<&str>) -> Result<String> {
         // If an explicit tarball URL is provided, use it directly
@@ -144,25 +150,26 @@ impl Fetcher {
             }
         }
 
-        // Otherwise, construct the URL from the default registry
-        let Some((user, name_and_ver)) = ident.split_once("/") else {
-            let Some((name, ver)) = ident.split_once("@") else {
-                return Err(Error::NoAtInPackageIdentifier);
-            };
+        // Otherwise, construct the URL from the default registry.
+        //
+        // A scoped package's leading `@` belongs to its name, so the separator
+        // is the first `@` after it. Splitting on `/` to find the scope would
+        // misread any `/` the specifier itself contains.
+        let search_start = usize::from(ident.starts_with('@'));
+        let sep = ident[search_start..]
+            .find('@')
+            .ok_or(Error::NoAtInPackageIdentifier)?
+            + search_start;
 
-            return Ok(format!(
-                "{}{}/-/{}-{}.tgz",
-                DEFAULT_REGISTRY, name, name, ver
-            ));
-        };
+        let (name, ver) = (&ident[..sep], &ident[sep + 1..]);
 
-        let Some((name, ver)) = name_and_ver.split_once("@") else {
-            return Err(Error::NoAtInPackageIdentifier);
-        };
+        // The tarball is served under the full (possibly scoped) name, but its
+        // filename drops the scope
+        let unscoped = name.rsplit('/').next().unwrap_or(name);
 
         Ok(format!(
-            "{}{}/{}/-/{}-{}.tgz",
-            DEFAULT_REGISTRY, user, name, name, ver
+            "{}{}/-/{}-{}.tgz",
+            DEFAULT_REGISTRY, name, unscoped, ver
         ))
     }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`deserialize_package` dispatches lockfile entries purely on their arity. Newer versions of bun append an integrity hash to `github:` and `git+` entries, which gives them arity 4 — the same shape as an npm package:

```jsonc
// arity 3, handled correctly today
"dayjs": ["dayjs@github:iamkun/dayjs#45bf6a3", {}, "iamkun-dayjs-45bf6a3"],

// arity 4, routed to deserialize_npm_package
"@kenn-io/kata-ui": ["kata@github:kenn-io/kata#c668572", {}, "kenn-io-kata-c668572", "sha512-WiP4Se…"],
```

Those entries reach `deserialize_npm_package`, which asks `to_npm_url` to build a registry url out of a git specifier. There are two outcomes:

- **Scoped package** — silently produces a bogus `https://registry.npmjs.org/@scope/pkg/-/pkg-github:owner/repo#rev.tgz`, which fails much later at fetch time.
- **Unscoped package** — fails outright. `to_npm_url` looks for the scope separator by splitting on the first `/`, so for `kata@github:kenn-io/kata#c668572` it consumes the `/` between owner and repo and is left with `kata#c668572`, which has no `@` to split on:

```
[ERROR bun2nix]
    Failed to parse lockfile related JSON as rust type:
    Failed to deserialize package: Missing @ for package name and version declaration.

    Make sure all versions in your bun lockfile are formatted properly or try
    deleting it and running `bun install` to produce a fresh one
```

The advice in that message can't help: the lockfile is valid and a fresh `bun install` reproduces it. Any project with an unscoped github dependency is stuck.

## Fix

1. **Dispatch arity-4 entries on their specifier** — a new `4 if deserializer.has_git_or_github_specifier()` arm sends them to `deserialize_tarball_git_or_github_package`, so git and github packages are recognised whether or not bun recorded a hash for them. That method only reads the identifier, so the trailing hash is harmlessly ignored. Backed by a new public `is_git_or_github_identifier` helper with doctests.

2. **Harden `to_npm_url`** — it now finds the name/version separator the way `drain_package_specifier` already does, instead of inferring the scope from a `/`, so a specifier containing a slash can no longer be misread. This is defence in depth: after (1) a git specifier no longer reaches it.

## Testing

Built and tested against rustc 1.95.

- `cargo test --locked` — 7 doctests pass, 2 of them new.
- `rustfmt --check` clean on the touched files. `cargo clippy --all-targets` reports one `collapsible_if` warning in an untouched block; warning count is unchanged from the base commit.
- **No regression:** generated output for `templates/git-deps/bun.lock` (npm + `git+` + two arity-3 `github:` deps) is byte-identical before and after this change.
- **Reproduced and fixed**, using a synthetic lockfile with arity-4 github entries, scoped and unscoped:

  ```jsonc
  "packages": {
    "scoped":   ["@scope/pkg@github:iamkun/dayjs#45bf6a3", {}, "iamkun-dayjs-45bf6a3", "sha512-AAAA…"],
    "unscoped": ["dayjs@github:iamkun/dayjs#45bf6a3",      {}, "iamkun-dayjs-45bf6a3", "sha512-BBBB…"]
  }
  ```

  Before, this fails with `Missing @ for package name and version declaration`. After, it produces the same entry the arity-3 form does:

  ```nix
  "github:iamkun-dayjs-45bf6a3" = fetchFromGitHub {
    owner = "iamkun";
    repo = "dayjs";
    rev = "45bf6a3";
    hash = "sha256-E3r6M5Ydy7TtH4BrpnWT57BztbLn0HJXMklto4zMJ6w=";
  };
  ```

I did not add a template or `nix flake check` fixture for the arity-4 shape, since the lockfile bun generates depends on the bun version in the build environment — happy to add one if you'd prefer it pinned as a static fixture.
